### PR TITLE
Doesn't need networks defined

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,12 +9,5 @@ services:
     volumes:
       - ./config.yaml:/usr/local/bin/config.yaml:ro
     restart: unless-stopped
-    networks:
-      - web-network
     ports:
       - ${PORTS}
-
-networks:
-    web-network:
-        driver: bridge
-        external: true


### PR DESCRIPTION
Otherwise this fails with:
```
network web-network declared as external, but could not be found
```