### PR TITLE
Better config handling / Docker mount / Docker instructions / Fix home dir bug

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,10 @@
 node_test*
 node_1/bridge*
 node_2/bridge*
+
+# a .koinos directory of it exists here
+.koinos
+# make sure config.yml is not checked in
+config.yml
+# env files if those are used in the future
+.env

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,6 +14,7 @@ RUN go get ./... && \
 
 FROM alpine:latest
 COPY --from=builder /koinos-bridge/koinos_bridge /usr/local/bin
-COPY config.yml /root/~/.koinos/config.yml
+# instead of copying the config into the built image, mount it with --mount type=bind,source=/path/to/config.yml,target=/root/.koinos/config.yml
+# (SEE README)
 
-ENTRYPOINT [ "/usr/local/bin/koinos_bridge" ]
+CMD [ "/usr/local/bin/koinos_bridge" ]

--- a/README.md
+++ b/README.md
@@ -2,6 +2,66 @@
 
 # koinos-bridge-validator
 
+## Building and running with docker
+
+Requirements: `docker`. If you need to install docker on your VPC/server, you can do so on most systems like this:
+
+```
+curl -fsSL https://get.docker.com -o install-docker.sh
+sudo sh install-docker.sh
+```
+
+First fill out your config.yml based on the example.
+
+*FIME* - add more instructions here for filling in config.yml.
+
+Make a new directory in your home directory called `.koinos` and put your config.yml in there - this will be mounted inside the built container at runtime.
+
+Build the container:
+```
+docker build -t=koinos-bridge-validator:latest .
+```
+
+Run the container. This command will start a new container mapping your config.yml to inside the container at runtime. It is set to always restart so if the validator crashes, it will start back up (even if the VPC/server is rebooted). This assumes your API port will be 3020 and it maps the internal port of the container to the external port of your VPC/server.
+```
+docker run -d --name bridge-validator-1 -p 3020:3020 --restart always --mount type=bind,source="$HOME"/.koinos/config.yml,target=/root/.koinos/config.yml koinos-bridge-validator:latest
+```
+
+Follow the logs at any time (ctrl-c to exit, container will continue running):
+```
+docker logs -f bridge-validator-1
+```
+
+To stop the container:
+```
+docker stop bridge-validator-1
+```
+
+To start a stopped container:
+```
+docker start bridge-validator-1
+```
+
+If re-building the container after pulling in new source for an update, or if you need to run with new docker options, first remove the built container before running again:
+```
+docker rm bridge-validator-1
+```
+
+## Querying transactions from the validator
+
+Query transactions status
+```bash
+curl -X GET \
+  'http://localhost:3020/GetEthereumTransaction?TransactionId=0xc4400da5eb03fec6eb0450d1e02b694ea049d103e85ed0d10d568df2ee7800ad' \
+  --header 'Accept: */*'
+
+curl -X GET \
+  'http://localhost:3020/GetKoinosTransaction?TransactionId=0x12207638d5874c57ff042d9268927f79c8cd151d3ff0f94b2e366d154cc1c2d9807f' \
+  --header 'Accept: */*'
+```
+
+## For testing / running without docker (for development)
+
 command example:
 
 Start a node
@@ -16,15 +76,4 @@ go run cmd/koinos-bridge-validator/main.go -d "$(pwd)/node_1"
 Start test node 2
 ```bash
 go run cmd/koinos-bridge-validator/main.go -d "$(pwd)/node_2"
-```
-
-Query transactions status
-```bash
-curl -X GET \
-  'http://localhost:3000/GetEthereumTransaction?TransactionId=0xc4400da5eb03fec6eb0450d1e02b694ea049d103e85ed0d10d568df2ee7800ad' \
-  --header 'Accept: */*'
-
-curl -X GET \
-  'http://localhost:3000/GetKoinosTransaction?TransactionId=0x12207638d5874c57ff042d9268927f79c8cd151d3ff0f94b2e366d154cc1c2d9807f' \
-  --header 'Accept: */*'
 ```

--- a/cmd/koinos-bridge-validator/main.go
+++ b/cmd/koinos-bridge-validator/main.go
@@ -8,6 +8,8 @@ import (
 	"os"
 	"os/signal"
 	"path"
+	"path/filepath"
+	"strings"
 	"sync"
 	"syscall"
 
@@ -61,6 +63,15 @@ func main() {
 	baseDir := flag.StringP(basedirOption, "d", basedirDefault, "the base directory")
 
 	flag.Parse()
+
+	// Expand ~ to the home directory (otherwise you wind up with /home/user/~/.koinos)
+	if strings.HasPrefix(*baseDir, "~") {
+		homeDir, err := os.UserHomeDir()
+		if err != nil {
+			panic(fmt.Sprintf("Could not get home directory: %v", err))
+		}
+		*baseDir = filepath.Join(homeDir, (*baseDir)[1:])
+	}
 
 	var err error
 	*baseDir, err = koinosUtil.InitBaseDir(*baseDir)


### PR DESCRIPTION
This does the following:
1) This fixes an issue where `~` was not being expanded for the `baseDir` file path.
2) Switches to mounting the `config.yml` inside the docker container at runtime so people won't accidentally check in their `config.yml` (prevents leaking private keys) or push the built container to a docker repo.
3) Switched to `CMD` instead of `ENTRYPOINT` so the run command can be overridden if necessary at container launch
4) Added more things to .gitignore (like the `config.yml`) to prevent these from being checked in.
5) Added instructions to the `README` to build and run with docker.